### PR TITLE
Wrong launching function

### DIFF
--- a/Chapter2(UniqueParts).js
+++ b/Chapter2(UniqueParts).js
@@ -56,7 +56,7 @@ function scope3(print) {
     }
     console.log(insideIf);
 }
-scope2(true); // prints ''
+scope3(true); // prints ''
 
 var is20 = false; // boolean
 typeof is20; // boolean


### PR DESCRIPTION
To get expected result (prints ''') you have to launch `scope3` instead `score2` function